### PR TITLE
correct initialState details in product/tests.js

### DIFF
--- a/src/app/redux/ducks/busy/tests.js
+++ b/src/app/redux/ducks/busy/tests.js
@@ -53,6 +53,7 @@ const nonBlockingFailed = {
     },
 };
 
+/* eslint-disable func-names */
 describe( "busy reducer", function( ) {
     describe( "initial action", function( ) {
         context( "on general action", function( ) {

--- a/src/app/redux/ducks/cart/tests.js
+++ b/src/app/redux/ducks/cart/tests.js
@@ -8,6 +8,7 @@ const product = {
     permalink: "test",
 };
 
+/* eslint-disable func-names */
 describe( "cart reducer", function( ) {
     describe( "add to cart", function( ) {
         const action = {

--- a/src/app/redux/ducks/product/tests.js
+++ b/src/app/redux/ducks/product/tests.js
@@ -17,7 +17,7 @@ describe( "product reducer", function( ) {
 
         const initialState = {
             list: [ ],
-            detail: null,
+            details: null,
         };
 
         const result = reducer( initialState, action );

--- a/src/app/redux/ducks/product/tests.js
+++ b/src/app/redux/ducks/product/tests.js
@@ -2,6 +2,7 @@ import expect from "expect.js";
 import reducer from "./reducers";
 import types from "./types";
 
+/* eslint-disable func-names */
 describe( "product reducer", function( ) {
     describe( "fetch product", function( ) {
         const action = {

--- a/src/app/redux/ducks/session/tests.js
+++ b/src/app/redux/ducks/session/tests.js
@@ -2,6 +2,7 @@ import expect from "expect.js";
 import reducer from "./reducers";
 import types from "./types";
 
+/* eslint-disable func-names */
 describe( "session reducer", function( ) {
     describe( "login", function( ) {
         const action = {


### PR DESCRIPTION
when you run npm run test, you have the message
````
Unexpected key "detail" found in previous state received by the reducer. Expected to find one of the known reducer keys instead: "details", "list". Unexpected keys will be ignored.
````
This PR fixes the tests.js file to remove the warning.